### PR TITLE
17 enable copying block of code in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
 
 theme:
   name: material
-  pallete:
+  palette:
     scheme: slate
   features:
     - content.code.copy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ theme:
   name: material
   pallete:
     scheme: slate
+  features:
+    - content.code.copy
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
The commands in code block can be now copied via the button. Plus the theme is changed to dark mode.