### PR TITLE
22 create a docker environment for installing the arlib alternative routing library

### DIFF
--- a/docker/arlib/Dockerfile
+++ b/docker/arlib/Dockerfile
@@ -1,0 +1,65 @@
+
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake libboost-graph-dev \
+    libpthread-stubs0-dev \
+    gdal-bin libgdal-dev \
+    git curl \
+    python3 python3-dev python3-pip python3-setuptools python3-wheel vim
+
+
+# install RUST
+ENV RUSTUP_HOME="${INSTALL_DIR}/rustup"
+ENV CARGO_HOME="${INSTALL_DIR}/cargo"
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+
+
+# prepare ruth environment
+ENV RUTH_HOME=/ruth
+WORKDIR ${RUTH_HOME}
+
+# install py arlib
+RUN git clone https://project_1485_bot:glpat-gp8mAP8LjPbPGdUuZBdQ@code.it4i.cz/everest/py-arlib.git arlib
+
+WORKDIR ${RUTH_HOME}/arlib
+
+RUN git submodule init
+RUN git submodule update
+
+# NOTE: a dirty fix of external library arlib. It counts at SIGSTKSZ which is not available in new glibc.
+#       Now it can be compiled and used. plus it should not influence the library as it is among tests.
+# TODO: remove once fixed
+RUN sed -i 7355s/SIGSTKSZ/4196464/ external/arlib/external/catch/catch.hpp
+
+
+RUN mkdir build
+
+WORKDIR ${RUTH_HOME}/arlib/build
+
+RUN cmake ../
+RUN make
+
+# set the environment variables in order to work
+ENV LD_LIBRARY_PATH=${RUTH_HOME}/arlib/build/
+ENV PYTHONPATH=${RUTH_HOME}
+
+# install ruth depencies
+ENV RUTH_HOST_HOME=.
+
+RUN pip install -U pip setuptools wheel
+
+ENV TMP=/tmp
+COPY ${RUTH_HOST_HOME}/requirements.txt ${TMP}
+
+RUN pip install -r ${TMP}/requirements.txt
+
+COPY ${RUTH_HOST_HOME} ${RUTH_HOME}
+WORKDIR ${RUTH_HOME}
+
+RUN pip install .
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker/arlib/README.md
+++ b/docker/arlib/README.md
@@ -1,0 +1,46 @@
+# Dockerfile for usage with arlib library
+
+The arlib library for alternative routing written in C++ enforces the target platform to be linux. For the development purposes there is a docker file used to prepare the enviroment for testing the simulator.
+
+
+- **It works only on arlib branch of ruth repository.**
+
+- **It can be used for testing the simulator after local changes within the ruth.** `py-arlib` (python binding of C++ library) is fixed and downloaded from the repository.
+
+You can prepare the Docker image by running the following command from the `ruth` root directory. So you clone the `ruth` repostory, enter it, and call the command.
+
+``` shell
+docker build -t ruth-with-arlib -f docker/arlib/Dockerfile .
+```
+
+Once the image is buld you can run the container. After exiting the container it is removed so next time you have a fresh environment. If you need access to a host data/folder for output, mount a volume and use it as a path for input/output paramters.
+
+``` shell
+ docker run -it --rm --name ruth-with-arlib.con ruth-with-arlib:latest
+```
+
+Now you can test simulator
+
+``` shell
+ruth-simulator --departure-time="2021-06-16 07:00:00" --k-alternatives=4 --nproc=8 --out=simulation_record.pickle --seed=7 rank-by-prob-delay /ruth/benchmarks/hello-world/vehicles-state.parquet 70 500
+```
+
+## Make changes in ruth and test them
+
+Now any time you make a change you want to test you build an updated image with the same command.
+``` shell
+docker build -t ruth-with-arlib -f docker/arlib/Dockerfile .
+```
+
+As there is a previous version it just copy the local files and install ruth but all the dependencies are already installed hence the process is much faster. Then you can test it in the same way.
+
+If you make a change in `requirements.txt`, the installation build can take more time.
+
+If you make a change in `py-arlib` please delete the image and build it from scratch.
+
+``` shell
+docker image rm ruth-with-arlib
+docker system prune
+```
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 py-probduration @ git+https://project_1143_bot:glpat-QdQC3BdsxSKr7zZnQ2vt@code.it4i.cz/everest/py-probduration.git
+cffi
 osmnx
 lazy-object-proxy
 click


### PR DESCRIPTION
Prepared docker environment for working with arlib library with a description how to use it.

This pull request is made to `arlib` branch as it is valid only for it and until the issue #23 is solved, it does not have sense to have it in `main` branch.