### PR TITLE
Remove dependency on Rust and introduce alternatives and route selection interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,5 @@ python3 -m pip install git+https://github.com/It4innovations/ruth.git
 * IMPORTANT: in this version, the fastest route calculation is the default method. If you wish to use the shortest path calculation, navigate to the file "common.py" and switch the two last lines of code (in the function alternatives(vehicle, k). To switch you can simply leave uncommented the one you want to use - but just one of them can be used, they cannot be used simultaneously! 
 
 ``` sh
-ruth-simulator --departure-time="2021-06-16 07:00:00" --k-alternatives=4 --out=simulation_record.pickle --seed=7 rank-by-prob-delay INPUT-od-matrix-10-vehicles-town-resolution.parquet --prob_profile_path=prob-profile-for-2021-06-20T23:59:00+02:00--2021-06-27T23:59:00+02:00.mem 70 500
+ruth-simulator --departure-time="2021-06-16 07:00:00" --k-alternatives=4 --out=simulation_record.pickle --seed=7 run INPUT-od-matrix-10-vehicles-town-resolution.parquet
 ```
-

--- a/ruth/simulator/common.py
+++ b/ruth/simulator/common.py
@@ -47,10 +47,11 @@ def save_vehicles(vehicles, output_path: str):
     df.to_pickle(output_path)
 
 
-def advance_vehicle(vehicle, osm_route, departure_time, gv_db):
+def advance_vehicle(vehicle: Vehicle, osm_route: Route, departure_time, gv_db):
     """Advance a vehicle on a route."""
 
     dt = departure_time + vehicle.time_offset
+    osm_route = vehicle.concat_route_with_passed_part(osm_route)
 
     driving_route = Route(osm_route_to_segments(osm_route, vehicle.routing_map),
                           vehicle.frequency)

--- a/ruth/simulator/kernels.py
+++ b/ruth/simulator/kernels.py
@@ -1,11 +1,10 @@
 import json
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from ..vehicle import Vehicle
 
 Route = List[int]
 AlternativeRoutes = List[Route]
-
 
 # Alternatives
 class AlternativesProvider:
@@ -37,3 +36,24 @@ class ZeroMQDistributedAlternatives(AlternativesProvider):
         inputs = [json.dumps(x).encode() for x in od_paths]
         result = self.client.compute(inputs)
         return result
+
+
+VehicleWithPlans = Tuple[Vehicle, AlternativeRoutes]
+VehicleWithRoute = Tuple[Vehicle, Route]
+
+# Route selection
+class RouteSelectionProvider:
+    """
+    Provides implementation of route selection.
+    For a given list of alternatives (k per vehicle), select the best route for each vehicle.
+    """
+    def select_routes(self, route_possibilities: List[VehicleWithPlans]) -> List[VehicleWithRoute]:
+        raise NotImplementedError
+
+
+class FirstRouteSelection(RouteSelectionProvider):
+    """
+    Selects the first route for each car.
+    """
+    def select_routes(self, route_possibilities: List[VehicleWithPlans]) -> List[VehicleWithRoute]:
+        return [(vehicle, routes[0]) for (vehicle, routes) in route_possibilities]

--- a/ruth/simulator/kernels.py
+++ b/ruth/simulator/kernels.py
@@ -1,32 +1,38 @@
 import json
-from typing import List
+from typing import List, Optional
 
 from ..vehicle import Vehicle
 
+Route = List[int]
+AlternativeRoutes = List[Route]
 
-class KernelProvider:
+
+# Alternatives
+class AlternativesProvider:
     """
-    Provides implementation of computationally intensive tasks.
+    Provides implementation of computing alternatives.
+    For a given list of vehicles and parameter `k`, computes a list of routes for each vehicle.
     """
-    def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[List[List[int]]]:
+    def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[Optional[AlternativeRoutes]]:
         raise NotImplementedError
 
 
-class LocalKernelProvider(KernelProvider):
-    def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[List[List[int]]]:
-        result = []
-        for vehicle in vehicles:
-            result.append(vehicle.k_fastest_paths(k))
-            # result.append(vehicle.k_shortest_paths(k))
-        return result
+class FastestPathsAlternatives(AlternativesProvider):
+    def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[Optional[AlternativeRoutes]]:
+        return [vehicle.k_fastest_paths(k) for vehicle in vehicles]
 
 
-class ZeroMqKernelProvider(KernelProvider):
+class ShortestPathsAlternatives(AlternativesProvider):
+    def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[Optional[AlternativeRoutes]]:
+        return [vehicle.k_shortest_paths(k) for vehicle in vehicles]
+
+
+class ZeroMQDistributedAlternatives(AlternativesProvider):
     def __init__(self, port: int):
         from ..zeromq.src.client import Client
         self.client = Client(port=port)
 
-    def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[List[List[int]]]:
+    def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[Optional[AlternativeRoutes]]:
         od_paths = [(*v.next_routing_od_nodes, k) for v in vehicles]
         inputs = [json.dumps(x).encode() for x in od_paths]
         result = self.client.compute(inputs)

--- a/ruth/simulator/route.py
+++ b/ruth/simulator/route.py
@@ -1,0 +1,116 @@
+import math
+from datetime import datetime, timedelta
+from typing import List, Tuple
+
+import osmnx as ox
+
+from .kernels import Route
+from .segment import Segment, SegmentPosition, SpeedKph
+from ..data.map import Map
+from ..losdb import GlobalViewDb
+from ..vehicle import Vehicle
+
+
+def move_on_segment(
+        vehicle: Vehicle,
+        segments: List[Segment],
+        departure_time: datetime,
+        level_of_service: float
+) -> Tuple[datetime, SegmentPosition, SpeedKph]:
+    """
+    Moves the car on its current segment.
+    Returns (time, position, speed) at the end of the movement.
+    """
+    segment_position = vehicle.segment_position
+    segment = segments[segment_position.index]
+    assert segment_position.position < segment.length
+
+    # Speed in m/s
+    speed_mps = (segment.max_allowed_speed_kph * level_of_service) * (1000 / 3600)
+    if math.isclose(speed_mps, 0.0):
+        return (departure_time, segment_position, 0.0)
+
+    start = segment_position.position
+    frequency_s = vehicle.frequency.total_seconds()
+    elapsed_m = start + frequency_s * speed_mps
+
+    if elapsed_m < segment.length:
+        # We stay on the same segment
+        return (
+            departure_time + timedelta(seconds=frequency_s),
+            SegmentPosition(index=segment_position.index, position=elapsed_m),
+            speed_mps
+        )
+    else:
+        # We have moved to the end of the current segment, the car will jump to the
+        # beginning of the next one.
+        travel_distance_m = segment.length - start
+        travel_time = travel_distance_m / speed_mps
+        return (
+            departure_time + timedelta(seconds=travel_time),
+            SegmentPosition(segment_position.index + 1, 0.0),
+            speed_mps
+        )
+
+
+def advance_vehicle(vehicle: Vehicle, osm_route: Route, departure_time: datetime,
+                    gv_db: GlobalViewDb):
+    """Advance a vehicle on a route."""
+
+    dt = departure_time + vehicle.time_offset
+    # TODO: remove this and take into account only the rest of the route
+    osm_route = vehicle.concat_route_with_passed_part(osm_route)
+
+    driving_route = osm_route_to_py_segments(osm_route, vehicle.routing_map)
+
+    # update the current route
+    vehicle.set_current_route(osm_route)
+
+    if vehicle.segment_position.index < len(driving_route):
+        segment = driving_route[vehicle.segment_position.index]
+        los = gv_db.get(dt, segment)
+    else:
+        los = 1.0  # the end of the route
+
+    if los == float("inf"):
+        # in case the vehicle is stuck in traffic jam just move the time
+        vehicle.time_offset += vehicle.frequency
+    else:
+        time, segment_pos, assigned_speed_mps = move_on_segment(
+            vehicle, driving_route, dt, los
+        )
+        d = time - dt
+
+        # NOTE: _assumption_: the car stays on a single segment within one call of the `advance`
+        #       method on the driving route
+
+        # NOTE: the segment position index may end out of segments
+        if segment_pos.index < len(driving_route):
+            vehicle.store_fcd(dt, d, driving_route[segment_pos.index], segment_pos.position,
+                              assigned_speed_mps)
+
+        # update the vehicle
+        vehicle.time_offset += d
+        vehicle.set_position(segment_pos)
+
+        if vehicle.current_node == vehicle.dest_node:
+            # stop the processing in case the vehicle reached the end
+            vehicle.active = False
+
+    return vehicle
+
+
+def osm_route_to_py_segments(osm_route: Route, routing_map: Map) -> List[Segment]:
+    """Prepare list of segments based on route."""
+    edge_data = ox.utils_graph.get_route_edge_attributes(routing_map.network,
+                                                         osm_route)
+    edges = zip(osm_route, osm_route[1:])
+    return [
+        Segment(
+            id=f"OSM{from_}T{to_}",
+            length=data["length"],
+            max_allowed_speed_kph=data["speed_kph"],
+        )
+        # NOTE: the zip is correct as the starting node_id is of the interest
+        for i, ((from_, to_), data) in enumerate(zip(edges, edge_data))
+    ]

--- a/ruth/simulator/segment.py
+++ b/ruth/simulator/segment.py
@@ -1,0 +1,20 @@
+import dataclasses
+
+SpeedKph = float
+LengthMeters = float
+
+
+@dataclasses.dataclass(frozen=True)
+class SegmentPosition:
+    # Index of the segment
+    index: int
+    # Position within the segment (in meters)
+    position: LengthMeters
+
+
+@dataclasses.dataclass(frozen=True)
+class Segment:
+    id: str
+    # Length of th segment (in meters)
+    length: LengthMeters
+    max_allowed_speed_kph: SpeedKph

--- a/ruth/simulator/singlenode.py
+++ b/ruth/simulator/singlenode.py
@@ -8,7 +8,7 @@ from typing import Any, List, Dict, Tuple, Callable, NewType
 from probduration import VehiclePlan, Route, SegmentPosition
 
 from .common import advance_vehicle
-from .kernels import KernelProvider
+from .kernels import AlternativesProvider
 from .routeranking import Comparable
 from ..globalview import GlobalView
 from ..utils import osm_route_to_segments, route_to_osm_route, TimerSet, riffle_shuffle
@@ -43,7 +43,7 @@ class Simulator:
 
     def simulate(self,
                  route_ranking_fn: Callable[[GlobalView, VehiclePlans, List, Dict], Comparable],
-                 kernel_provider: KernelProvider,
+                 alternatives_provider: AlternativesProvider,
                  rr_fn_args=(),
                  rr_fn_kwargs=None,
                  extend_plans_fn: Callable[[VehiclePlans, List, Dict], Any] = lambda plans: plans,
@@ -93,7 +93,7 @@ class Simulator:
                                     if self.sim.is_vehicle_within_offset(v, offset)]
 
             with timer_set.get("alternatives"):
-                alts = self.alternatives(allowed_vehicles, kernel_provider)
+                alts = self.alternatives(allowed_vehicles, alternatives_provider)
 
             # collect vehicles without alternative and finish them
             with timer_set.get("collect"):
@@ -157,7 +157,7 @@ class Simulator:
             step += 1
         logger.info(f"Simulation done in {self.sim.duration}.")
 
-    def alternatives(self, vehicles, kernel_provider: KernelProvider):
+    def alternatives(self, vehicles, kernel_provider: AlternativesProvider):
         """Provide a list of alternative routes for vehicle's current origin to destination. The resulting list has
         the same length as the provided vehicles and keeping the order of vehicles"""
 

--- a/ruth/simulator/singlenode.py
+++ b/ruth/simulator/singlenode.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from datetime import datetime, timedelta
 from itertools import groupby
-from typing import Callable, Dict, List, NewType, Tuple
+from typing import Callable, List, NewType, Optional, Tuple
 
 from probduration import Route, SegmentPosition, VehiclePlan
 
@@ -39,9 +39,7 @@ class Simulator:
             self,
             alternatives_provider: AlternativesProvider,
             route_selection_provider: RouteSelectionProvider,
-            end_step_fn: Callable[[Simulation, List, Dict], None] = lambda *_: None,
-            es_fn_args=(),
-            es_fn_kwargs=None
+            end_step_fn: Optional[Callable[[Simulation], None]] = None,
     ):
         """Perform the simulation.
 
@@ -114,9 +112,9 @@ class Simulator:
                 f"{step}. active: {len(allowed_vehicles)}, duration: {step_dur / timedelta(milliseconds=1)} ms")
             self.sim.duration += step_dur
 
-            with timer_set.get("end_step"):
-                es_fn_kwargs_ = {} if es_fn_kwargs is None else es_fn_kwargs
-                end_step_fn(self.state, *es_fn_args, **es_fn_kwargs_)
+            if end_step_fn is not None:
+                with timer_set.get("end_step"):
+                    end_step_fn(self.state)
 
             self.sim.save_step_info(step, len(allowed_vehicles), step_dur, timer_set.collect())
 

--- a/ruth/tools/simulator.py
+++ b/ruth/tools/simulator.py
@@ -48,11 +48,11 @@ def prepare_simulator(common_args: CommonArgs, vehicles_path) -> SingleNodeSimul
     return SingleNodeSimulator(simulation)
 
 
-def store_simulation_at_walltime():
+def store_simulation_at_walltime(walltime: Optional[timedelta], name: str):
     saved = False
     start_time = datetime.now()
 
-    def store(simulation: Simulation, walltime: Optional[timedelta], name: str):
+    def store(simulation: Simulation):
         nonlocal saved
         """Store the state of the simulation at walltime."""
         if walltime is not None and (datetime.now() - start_time) >= walltime and not saved:
@@ -279,7 +279,10 @@ def run(ctx, vehicles_path: Path, alternatives: AlternativesImpl,
     task_id = f"-task-{common_args.task_id}" if common_args.task_id is not None else ""
 
     simulator = prepare_simulator(common_args, vehicles_path)
-    end_step_fn = store_simulation_at_walltime() if walltime is not None else lambda *_: None
+    end_step_fn = (
+        store_simulation_at_walltime(walltime, f"rank_by_duration{task_id}")
+        if walltime is not None else None
+    )
 
     alternatives_provider = create_alternatives_provider(alternatives)
     route_selection_provider = create_route_selection_provider(route_selection)
@@ -287,7 +290,6 @@ def run(ctx, vehicles_path: Path, alternatives: AlternativesImpl,
         alternatives_provider=alternatives_provider,
         route_selection_provider=route_selection_provider,
         end_step_fn=end_step_fn,
-        es_fn_args=(walltime, f"rank_by_duration{task_id}")
     )
     simulator.state.store(out)
 

--- a/ruth/utils.py
+++ b/ruth/utils.py
@@ -124,21 +124,3 @@ class TimerSet:
 
     def collect(self):
         return dict((timer.name, timer.duration_ms) for timer in self.timers)
-
-
-def riffle_shuffle(a: list, b: list, index_to_a: list):
-    """Takes two lists and shuffle them together according to the index to the first provided list."""
-
-    joined = []
-
-    i, idx_a, idx_b = 0, 0, 0
-    for j in range(len(a + b)):
-        if i < len(index_to_a) and index_to_a[i] == j:
-            joined.append(a[idx_a])
-            idx_a += 1
-            i += 1
-        else:
-            joined.append(b[idx_b])
-            idx_b += 1
-
-    return joined

--- a/ruth/utils.py
+++ b/ruth/utils.py
@@ -1,11 +1,9 @@
 import re
-import osmnx as ox
-from probduration import Segment
-from datetime import datetime, timedelta
 import time
+from datetime import datetime, timedelta
 
-from .data.map import Map
 from .data.border import Border, BorderType, PolygonBorderDef
+from .data.map import Map
 from .metaclasses import Singleton
 
 
@@ -16,7 +14,6 @@ def get_map(polygon: str,
             with_speeds=False,
             data_dir="./data",
             load_from_cache=True):
-
     """Get map based on polygon."""
     border_def = PolygonBorderDef(polygon, on_disk=on_disk)
     border_kind = BorderType.parse(kind)
@@ -24,22 +21,6 @@ def get_map(polygon: str,
     border = Border(name_, border_def, border_kind, data_dir, load_from_cache)
 
     return Map(border, with_speeds=with_speeds)
-
-
-def osm_route_to_segments(osm_route, routing_map):
-    """Prepare list of segments based on route."""
-    edge_data = ox.utils_graph.get_route_edge_attributes(routing_map.network,
-                                                         osm_route)
-    edges = zip(osm_route, osm_route[1:])
-    return [
-        Segment(
-            f"OSM{from_}T{to_}",
-            data["length"],
-            data["speed_kph"],
-        )
-        # NOTE: the zip is correct as the starting node_id is of the interest
-        for i, ((from_, to_), data) in enumerate(zip(edges, edge_data))
-    ]
 
 
 class SegmentIdParser:
@@ -59,19 +40,6 @@ def parse_segment_id(segment_id):
     p = SegmentIdParser()
 
     return p.parse(segment_id)
-
-
-def route_to_osm_route(route):
-    osm_route = []
-    for i in range(len(route) - 1):
-        seg = route[i]
-        node_from, _ = parse_segment_id(seg.id)
-        osm_route.append(node_from)
-    last_seg = route[-1]
-    node_from, node_to = parse_segment_id(last_seg.id)
-    osm_route.extend([node_from, node_to])
-
-    return osm_route
 
 
 def round_timedelta(td: timedelta, freq: timedelta):


### PR DESCRIPTION
This PR changes and simplifies the structure of the simulator. Both alternatives and route selection implementations are now provided via interfaces, and it's thus easily possible to implement various implementations of these algorithms. PTDR is not implemented yet, it would need to be adapted to match the new interfaces.

The movement of a vehicle (`advance_vehicle`) has now also been rewritten from Rust to Python. If PTDR is not needed, the Rust binding can now be completely removed from the simulator.

To start the simulator, you can run this command:
```bash
python3 -m ruth.tools.simulator run <path-to-vehicles> [--alternatives <alternatives impl>] [--route-selection <route selection impl>]
```