### PR TITLE
Allow movement of vehicles without a route

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/ruth/tools/simulator.py",
             "console": "integratedTerminal",
-            "args": "--walltime-s=1000 --departure-time=\"2021-06-16T07:00:00\" --k-alternatives=3 --nproc=8 --out=2originTo1dest_ant.pickle --seed=7 rank-by-prob-delay ${workspaceFolder}/benchmarks/prague/2K_15052023_2_whole_prague.parquet 30 1",
+            "args": "--departure-time=\"2021-06-16T07:00:00\" --k-alternatives=3 --out=2originTo1dest_ant.pickle --seed=7 run ${workspaceFolder}/benchmarks/prague/2K_15052023_2_whole_prague.parquet",
             "justMyCode": true,
             "cwd": "${workspaceFolder}",
             "env": {

--- a/ruth/globalview.py
+++ b/ruth/globalview.py
@@ -1,11 +1,16 @@
 
 import pickle
 import operator
+from typing import TYPE_CHECKING
+
 import pandas as pd
 from datetime import timedelta
 from collections import defaultdict
 
 from .utils import parse_segment_id
+
+if TYPE_CHECKING:
+    from .simulator.simulation import FCDRecord
 
 
 class GlobalView:
@@ -14,13 +19,13 @@ class GlobalView:
         self.data = [] if data is None else data
         self.by_segment = self.construct_by_segments_()
 
-    def add(self, vehicle_id, hrs):
-        rows = [(dt, seg_id, vehicle_id, start_offset, speed, segment_length, status)
-                for dt, seg_id, start_offset, speed, segment_length, status in hrs]
-        self.data += rows
+    def add(self, fcd: "FCDRecord"):
+        self.data.append((
+            fcd.datetime, fcd.segment_id, fcd.vehicle_id, fcd.start_offset, fcd.speed,
+            fcd.segment_length, fcd.status
+        ))
 
-        for dt, seg_id, *_ in hrs:
-            self.by_segment[seg_id].append((dt, vehicle_id))
+        self.by_segment[fcd.segment_id].append((fcd.datetime, fcd.vehicle_id))
 
     def number_of_vehicles_in_time_at_segment(self, datetime, segment_id, tolerance=None):
         tolerance = tolerance if tolerance is not None else timedelta(seconds=0)

--- a/ruth/simulator/kernels.py
+++ b/ruth/simulator/kernels.py
@@ -1,9 +1,9 @@
 import json
 from typing import List, Optional, Tuple
 
+from .segment import Route
 from ..vehicle import Vehicle
 
-Route = List[int]
 AlternativeRoutes = List[Route]
 
 # Alternatives

--- a/ruth/simulator/route.py
+++ b/ruth/simulator/route.py
@@ -5,6 +5,7 @@ from typing import List, Tuple
 import osmnx as ox
 
 from .segment import Route, Segment, SegmentPosition, SpeedKph
+from .simulation import FCDRecord
 from ..data.map import Map
 from ..losdb import GlobalViewDb
 from ..vehicle import Vehicle
@@ -53,13 +54,15 @@ def move_on_segment(
 
 
 def advance_vehicle(vehicle: Vehicle, departure_time: datetime,
-                    gv_db: GlobalViewDb):
+                    gv_db: GlobalViewDb) -> List[FCDRecord]:
     """Advance a vehicle on a route."""
 
     dt = departure_time + vehicle.time_offset
     osm_route = vehicle.osm_route
 
     driving_route = osm_route_to_py_segments(osm_route, vehicle.routing_map)
+
+    fcds = []
 
     if vehicle.segment_position.index < len(driving_route):
         segment = driving_route[vehicle.segment_position.index]
@@ -81,7 +84,7 @@ def advance_vehicle(vehicle: Vehicle, departure_time: datetime,
 
         # NOTE: the segment position index may end out of segments
         if segment_pos.index < len(driving_route):
-            vehicle.store_fcd(dt, d, driving_route[segment_pos.index], segment_pos.position,
+            fcds = generate_fcds(vehicle, dt, d, driving_route[segment_pos.index], segment_pos.position,
                               assigned_speed_mps)
 
         # update the vehicle
@@ -92,7 +95,7 @@ def advance_vehicle(vehicle: Vehicle, departure_time: datetime,
             # stop the processing in case the vehicle reached the end
             vehicle.active = False
 
-    return vehicle
+    return fcds
 
 
 def osm_route_to_py_segments(osm_route: Route, routing_map: Map) -> List[Segment]:
@@ -109,3 +112,44 @@ def osm_route_to_py_segments(osm_route: Route, routing_map: Map) -> List[Segment
         # NOTE: the zip is correct as the starting node_id is of the interest
         for i, ((from_, to_), data) in enumerate(zip(edges, edge_data))
     ]
+
+
+def generate_fcds(vehicle: Vehicle, start_offset: datetime, duration: timedelta, segment: Segment,
+                  start_position: float, speed: float) -> List[FCDRecord]:
+    fcds = []
+
+    step_m = speed * (vehicle.fcd_sampling_period / timedelta(seconds=1))
+
+    start = start_position
+    current_offset = start_offset
+    end_offset = start_offset + duration
+    while current_offset + vehicle.fcd_sampling_period < end_offset and \
+            start + step_m < segment.length:
+        start += step_m
+        current_offset += vehicle.fcd_sampling_period
+        fcds.append(FCDRecord(
+            datetime=current_offset,
+            vehicle_id=vehicle.id,
+            segment_id=segment.id,
+            segment_length=segment.length,
+            start_offset=start,
+            speed=speed,
+            status=vehicle.status
+        ))
+
+    step_m = speed * ((end_offset - current_offset) / timedelta(seconds=1))
+    if start + step_m < segment.length:
+        # TODO: the question is wheather to store all the cars at the end of period or
+        # rather return the difference (end_offset - _last_ current_offset) and take it as
+        # a parameter for the next round of storing. In this way all the cars would be sampled
+        # with an exact step (car dependent as each car can have its own sampling period)
+        fcds.append(FCDRecord(
+            datetime=end_offset,
+            vehicle_id=vehicle.id,
+            segment_id=segment.id,
+            segment_length=segment.length,
+            start_offset=start + step_m,
+            speed=speed,
+            status=vehicle.status
+        ))
+    return fcds

--- a/ruth/simulator/route.py
+++ b/ruth/simulator/route.py
@@ -4,8 +4,7 @@ from typing import List, Tuple
 
 import osmnx as ox
 
-from .kernels import Route
-from .segment import Segment, SegmentPosition, SpeedKph
+from .segment import Route, Segment, SegmentPosition, SpeedKph
 from ..data.map import Map
 from ..losdb import GlobalViewDb
 from ..vehicle import Vehicle

--- a/ruth/simulator/route.py
+++ b/ruth/simulator/route.py
@@ -52,18 +52,14 @@ def move_on_segment(
         )
 
 
-def advance_vehicle(vehicle: Vehicle, osm_route: Route, departure_time: datetime,
+def advance_vehicle(vehicle: Vehicle, departure_time: datetime,
                     gv_db: GlobalViewDb):
     """Advance a vehicle on a route."""
 
     dt = departure_time + vehicle.time_offset
-    # TODO: remove this and take into account only the rest of the route
-    osm_route = vehicle.concat_route_with_passed_part(osm_route)
+    osm_route = vehicle.osm_route
 
     driving_route = osm_route_to_py_segments(osm_route, vehicle.routing_map)
-
-    # update the current route
-    vehicle.set_current_route(osm_route)
 
     if vehicle.segment_position.index < len(driving_route):
         segment = driving_route[vehicle.segment_position.index]

--- a/ruth/simulator/segment.py
+++ b/ruth/simulator/segment.py
@@ -1,7 +1,10 @@
 import dataclasses
+from typing import List
 
 SpeedKph = float
 LengthMeters = float
+
+Route = List[int]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ruth/simulator/simulation.py
+++ b/ruth/simulator/simulation.py
@@ -1,17 +1,15 @@
 import pickle
-import pylru
-import pandas as pd
-
-from collections import defaultdict
-from dataclasses import dataclass, field, InitVar, asdict
+from dataclasses import InitVar, asdict, dataclass
 from datetime import datetime, timedelta
 from random import random, seed as rnd_seed
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
+
+import pandas as pd
 
 from ..globalview import GlobalView
 from ..losdb import GlobalViewDb
-from ..vehicle import Vehicle
 from ..utils import round_timedelta
+from ..vehicle import Vehicle
 
 
 @dataclass
@@ -19,7 +17,8 @@ class VehicleUpdate:
     """Join the updated vehicle (after advance) and leap history of that move."""
 
     vehicle: Vehicle
-    leap_history: List[Tuple[datetime, str, float, float, float, str]]  # TODO: make a leap history data class
+    leap_history: List[
+        Tuple[datetime, str, float, float, float, str]]  # TODO: make a leap history data class
 
 
 @dataclass
@@ -117,7 +116,8 @@ class Simulation:
         return round_timedelta(offset, self.setting.round_freq)
 
     def compute_current_offset(self):
-        return min(filter(None, map(lambda v: v.time_offset if v.active else None, self.vehicles)), default=None)
+        return min(filter(None, map(lambda v: v.time_offset if v.active else None, self.vehicles)),
+                   default=None)
 
     def update(self, updates: List[VehicleUpdate]):
         vd = dict((v.id, v) for v in self.vehicles)
@@ -142,9 +142,10 @@ class Simulation:
             raise Exception("Empty steps info cannot be converted to DataFrame.")
 
         first = self.steps_info[0]
-        return pd.DataFrame([(si.step, si.n_active, si.duration / timedelta(milliseconds=1), *si.parts.values())
-                             for si in self.steps_info],
-                            columns=["step", "n_active", "duration"] + list(first.parts.keys()))
+        return pd.DataFrame(
+            [(si.step, si.n_active, si.duration / timedelta(milliseconds=1), *si.parts.values())
+             for si in self.steps_info],
+            columns=["step", "n_active", "duration"] + list(first.parts.keys()))
 
     @property
     def last_step(self):

--- a/ruth/simulator/singlenode.py
+++ b/ruth/simulator/singlenode.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Callable, Optional
 
-from .kernels import AlternativesProvider, RouteSelectionProvider, VehicleWithRoute
+from .kernels import AlternativesProvider, RouteSelectionProvider
 from .route import advance_vehicle
 from .simulation import Simulation, VehicleUpdate
 from ..losdb import GlobalViewDb
@@ -80,7 +80,8 @@ class Simulator:
                     vehicle.update_followup_route(route)
 
             with timer_set.get("advance_vehicle"):
-                vehicle_updates = [self.advance_vehicle(vehicle, offset) for vehicle in allowed_vehicles]
+                vehicle_updates = [self.advance_vehicle(vehicle, offset) for vehicle in
+                                   allowed_vehicles]
 
             with timer_set.get("update"):
                 self.sim.update(vehicle_updates)

--- a/ruth/simulator/singlenode.py
+++ b/ruth/simulator/singlenode.py
@@ -109,7 +109,7 @@ class Simulator:
                 with timer_set.get("end_step"):
                     end_step_fn(self.state)
 
-            print(timer_set.collect())
+            # print(timer_set.collect())
 
             self.sim.save_step_info(step, len(allowed_vehicles), step_dur, timer_set.collect())
 

--- a/ruth/tools/odmatrix2simulatorinput.py
+++ b/ruth/tools/odmatrix2simulatorinput.py
@@ -100,7 +100,6 @@ def convert(od_matrix_path, csv_separator, frequency, fcd_sampling_period, borde
         0, 0.0,
         frequency, fcd_sampling_period,
         f"{b_def.md5()}_{border_kind}", border_kind, border_poly.wkt)
-    df["leap_history"] = np.empty((len(odm_df), 0)).tolist()
 
     df[["time_offset", "frequency", "fcd_sampling_period"]] = \
         df[["time_offset", "frequency", "fcd_sampling_period"]].applymap(lambda seconds: timedelta(seconds=seconds))

--- a/ruth/tools/preprocessbenchmarkdata.py
+++ b/ruth/tools/preprocessbenchmarkdata.py
@@ -55,9 +55,6 @@ def prepare_vehicle_state(df: pd.DataFrame) -> pd.DataFrame:
     # each car starts with an empty route, only origin and destination is known at that point
     df["osm_route"] = np.empty((len(df), 0)).tolist()  # empty list
 
-    # a history of a one leap, i.e., a series of smaller steps in simulation
-    df["leap_history"] = np.empty((len(df), 0)).tolist()  # empty list
-
     df["status"] = "not_started"
     return df[list(map(lambda field: field.name, fields(Vehicle)))]
 

--- a/ruth/tools/simulator.py
+++ b/ruth/tools/simulator.py
@@ -10,10 +10,10 @@ from typing import List, Optional
 import click
 from probduration import HistoryHandler
 
-from ..losdb import FreeFlowDb, ProbProfileDb
-from ..simulator import RouteRankingAlgorithms, SimSetting, Simulation, SingleNodeSimulator, \
+from ruth.losdb import FreeFlowDb, ProbProfileDb
+from ruth.simulator import RouteRankingAlgorithms, SimSetting, Simulation, SingleNodeSimulator, \
     load_vehicles
-from ..simulator.kernels import AlternativesProvider, FastestPathsAlternatives, \
+from ruth.simulator.kernels import AlternativesProvider, FastestPathsAlternatives, \
     FirstRouteSelection, RouteSelectionProvider, ShortestPathsAlternatives, \
     ZeroMQDistributedAlternatives
 
@@ -185,7 +185,7 @@ def rank_by_prob_delay(ctx,
     "driver is seeing in front of her/him".
     """
 
-    raise NotImplementedError
+    #raise NotImplementedError
     common_args = ctx.obj['common-args']
     out = common_args.out
     walltime = common_args.walltime

--- a/ruth/vehicle.py
+++ b/ruth/vehicle.py
@@ -9,7 +9,7 @@ import pandas as pd
 from networkx.exception import NodeNotFound
 
 from .data.map import Map
-from .simulator.segment import SegmentPosition
+from .simulator.segment import SegmentPosition, Route
 from .utils import get_map, round_timedelta
 
 

--- a/ruth/vehicle.py
+++ b/ruth/vehicle.py
@@ -136,13 +136,13 @@ class Vehicle:
             print(f"vehicle: {self.id}: {ex}", file=sys.stderr)
             return None
 
-    def concat_route_with_passed_part(self, osm_route):
+    def update_followup_route(self, osm_route: Route):
+        """
+        Updates the route from the current node to the destination node.
+        """
+        assert osm_route[-1] == self.dest_node
         node_index = self.next_routing_start.index
-        return self.osm_route[:node_index] + osm_route
-
-    def set_current_route(self, osm_route):
-        """Set the current route."""
-        self.osm_route = osm_route
+        self.osm_route = self.osm_route[:node_index] + osm_route
 
     @property
     def segment_position(self) -> SegmentPosition:

--- a/ruth/vehicle.py
+++ b/ruth/vehicle.py
@@ -9,7 +9,7 @@ import pandas as pd
 from networkx.exception import NodeNotFound
 
 from .data.map import Map
-from .simulator.segment import SegmentPosition, Route
+from .simulator.segment import Route, SegmentPosition
 from .utils import get_map, round_timedelta
 
 


### PR DESCRIPTION
This PR changes the logic of the simulator so that vehicles that do not receive any route (alternatives) can still drive ahead. This should work around issues where a car temporarily cannot get a new route (e.g. if there is some blockage on the route). In this case, the car should still be able to move in the future, instead of being deactivated instantly.

I have also refactored FCD storing so that FCDs are not stored inside each vehicle, but rather returned explicitly from `advance_vehicle`.