### PR TITLE
Implement distributed alternatives computation

### DIFF
--- a/ruth/simulator/kernels.py
+++ b/ruth/simulator/kernels.py
@@ -32,9 +32,12 @@ class ZeroMQDistributedAlternatives(AlternativesProvider):
         self.client = Client(port=port)
 
     def compute_alternatives(self, vehicles: List[Vehicle], k: int) -> List[Optional[AlternativeRoutes]]:
-        od_paths = [(*v.next_routing_od_nodes, k) for v in vehicles]
-        inputs = [json.dumps(x).encode() for x in od_paths]
-        result = self.client.compute(inputs)
+        inputs = [json.dumps({
+            "start": v.next_routing_od_nodes[0],
+            "destination": v.next_routing_od_nodes[1],
+            "max_routes": k
+        }).encode() for v in vehicles]
+        result = self.client.compute(kernel="alternatives", inputs=inputs)
         return result
 
 
@@ -56,4 +59,5 @@ class FirstRouteSelection(RouteSelectionProvider):
     Selects the first route for each car.
     """
     def select_routes(self, route_possibilities: List[VehicleWithPlans]) -> List[VehicleWithRoute]:
+        # TODO: react better to situations where no route is found
         return [(vehicle, routes[0]) for (vehicle, routes) in route_possibilities]

--- a/ruth/tools/simulator.py
+++ b/ruth/tools/simulator.py
@@ -242,6 +242,7 @@ def rank_by_prob_delay(ctx,
 class AlternativesImpl(str, enum.Enum):
     FASTEST_PATHS = "fastest-paths"
     SHORTEST_PATHS = "shortest-paths"
+    DISTRIBUTED = "distributed"
 
 
 def create_alternatives_provider(alternatives: AlternativesImpl) -> AlternativesProvider:
@@ -249,6 +250,9 @@ def create_alternatives_provider(alternatives: AlternativesImpl) -> Alternatives
         return FastestPathsAlternatives()
     elif alternatives == AlternativesImpl.SHORTEST_PATHS:
         return ShortestPathsAlternatives()
+    elif alternatives == AlternativesImpl.DISTRIBUTED:
+        # TODO: parse port from CLI
+        return ZeroMQDistributedAlternatives(port=5555)
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
This PR adds an implementation of alternatives that offloads the computation to a separate process over ZeroMQ. The distributed part is implemented in [evkit](https://code.it4i.cz/everest/evkit).

(Re)loading of the alternatives graph/map is not implemented yet, but that can be done separately.