### PR TITLE
Temporary speeds

### DIFF
--- a/ruth/data/map.py
+++ b/ruth/data/map.py
@@ -104,7 +104,7 @@ class Map(metaclass=Singleton):
     @property
     def name(self):
         """Name of the map."""
-        return self.border.name + "_" + self.download_date
+        return self.border.name + "_" + self.download_date.replace(":", "-")
 
     def get_travel_time(self, node_from: int, node_to: int, speed_kph: SpeedKph):
         return float('inf') if speed_kph == 0 else float(

--- a/ruth/data/map.py
+++ b/ruth/data/map.py
@@ -107,13 +107,6 @@ class Map(metaclass=Singleton):
         return float('inf') if speed_kph == 0 else float(
             self.segment_lengths[(node_from, node_to)]) * 3.6 / float(speed_kph)
 
-    def get_current_travel_time(self, route: List[int]):
-        total_travel_time = 0
-        for node_from, node_to in zip(route[:-1], route[1:]):
-            total_travel_time += self.current_network[node_from][node_to]['current_travel_time']
-        return total_travel_time
-
-
     def init_current_speeds(self):
         speeds = nx.get_edge_attributes(self.current_network, name='speed_kph')
         travel_times = {}
@@ -138,6 +131,12 @@ class Map(metaclass=Singleton):
 
     def get_original_max_speed(self, node_from: int, node_to: int):
         return self.original_network[node_from][node_to]['speed_kph']
+
+    def is_route_closed(self, route: List[int]):
+        for node_from, node_to in zip(route[:-1], route[1:]):
+            if self.get_current_max_speed(node_from, node_to) == 0:
+                return True
+        return False
 
     def set_data_dir(self, path):
         if self.data_dir is not None:

--- a/ruth/globalview.py
+++ b/ruth/globalview.py
@@ -83,7 +83,7 @@ class GlobalView:
             return None
         return sum(speeds) / len(speeds)
 
-    def get_segment_speed(self, node_from, node_to, routing_map: Map) -> SpeedKph:
+    def get_segment_speed(self, node_from, node_to) -> SpeedKph:
         speeds = {}
         by_segment = self.by_segment[get_osm_segment_id(node_from, node_to)]
         by_segment.sort(key=lambda x: x[0])
@@ -91,7 +91,7 @@ class GlobalView:
             speeds[vehicle_id] = speed
         speeds = list(speeds.values())
         if len(speeds) == 0:
-            return routing_map.get_segment_max_speed(node_from, node_to)
+            return SpeedKph(float('inf'))
         return SpeedKph(sum(speeds) / len(speeds))
 
     def to_dataframe(self):  # todo: maybe process in chunks

--- a/ruth/globalview.py
+++ b/ruth/globalview.py
@@ -77,6 +77,12 @@ class GlobalView:
     def level_of_service_in_time_at_segment(self, datetime, segment):
         return self.level_of_service_in_front_of_vehicle(datetime, segment, -1, 0, None)
 
+    def speed_in_time_at_segment(self, datetime, segment):
+        speeds = [speed for dt, _, _, speed in self.by_segment.get(segment.id, []) if dt == datetime]
+        if len(speeds) == 0:
+            return None
+        return sum(speeds) / len(speeds)
+
     def get_segment_speed(self, node_from, node_to, routing_map: Map) -> SpeedKph:
         speeds = {}
         by_segment = self.by_segment[get_osm_segment_id(node_from, node_to)]

--- a/ruth/simulator/kernels.py
+++ b/ruth/simulator/kernels.py
@@ -38,8 +38,7 @@ class AlternativesProvider:
             for_vehicle = []
             for alternative in alternatives_for_vehicle:
                 # calculate travel time for alternative
-                travel_time = routing_map.get_current_travel_time(alternative)
-                if travel_time != float("inf"):
+                if not routing_map.is_route_closed(alternative):
                     for_vehicle.append(alternative)
             filtered_alternatives.append(for_vehicle)
         return filtered_alternatives

--- a/ruth/simulator/kernels.py
+++ b/ruth/simulator/kernels.py
@@ -28,6 +28,22 @@ class AlternativesProvider:
         """
         raise NotImplementedError
 
+    def remove_infinity_alternatives(self, alternatives: List[AlternativeRoutes], routing_map: Map) -> List[
+        AlternativeRoutes]:
+        """
+        Removes alternatives that contain infinity.
+        """
+        filtered_alternatives = []
+        for alternatives_for_vehicle in alternatives:
+            for_vehicle = []
+            for alternative in alternatives_for_vehicle:
+                # calculate travel time for alternative
+                travel_time = routing_map.get_current_travel_time(alternative)
+                if travel_time != float("inf"):
+                    for_vehicle.append(alternative)
+            filtered_alternatives.append(for_vehicle)
+        return filtered_alternatives
+
 
 class FastestPathsAlternatives(AlternativesProvider):
     def compute_alternatives(self, map: Map, vehicles: List[Vehicle], k: int) -> List[
@@ -145,6 +161,7 @@ class ZeroMQDistributedPTDRRouteSelection(RouteSelectionProvider):
     Sends routes to a distributed node that calculates a Monte Carlo simulation and returns
     the shortest route for each car.
     """
+
     def select_routes(self, route_possibilities: List[VehicleWithPlans]) -> List[VehicleWithRoute]:
         messages = [Message(kind="monte-carlo", data={
             "routes": routes,

--- a/ruth/simulator/queues.py
+++ b/ruth/simulator/queues.py
@@ -10,8 +10,13 @@ class QueuesManager:
     def add_to_queue(self, vehicle: Vehicle):
         self.queues[(vehicle.current_node, vehicle.next_node)].append(vehicle)
 
+    def remove_inactive_vehicle(self, vehicle: Vehicle):
+        for queue in self.queues.values():
+            if vehicle in queue:
+                queue.remove(vehicle)
+
     def remove_vehicle(self, vehicle: Vehicle, node_from, node_to):
         queue = self.queues[(node_from, node_to)]
-        if len(queue) != 0:
-            popped_vehicle = queue.popleft()
-            assert popped_vehicle == vehicle
+        assert len(queue) != 0
+        popped_vehicle = queue.popleft()
+        assert popped_vehicle == vehicle

--- a/ruth/simulator/route.py
+++ b/ruth/simulator/route.py
@@ -114,6 +114,7 @@ def advance_vehicle(vehicle: Vehicle, departure_time: datetime,
         if vehicle.next_node == vehicle.dest_node:
             # stop the processing in case the vehicle reached the end
             vehicle.active = False
+            queues_manager.remove_inactive_vehicle(vehicle)
 
         elif segment_pos_old != vehicle.segment_position:
             # if the vehicle is at the end of the segment and was not there before, add it to the queue
@@ -205,8 +206,6 @@ def advance_vehicles_with_queues(vehicles_to_be_moved: List[Vehicle], departure_
         current_vehicle_list = vehicles_to_be_moved if len(vehicles_to_be_moved) > 0 else vehicles_undecided
         vehicle = current_vehicle_list[0]
         queue = queues_manager.queues[(vehicle.current_node, vehicle.next_node)]
-        while len(queue) != 0 and queue[0].is_active:
-            queues_manager.remove_vehicle(queue[0], vehicle.current_node, vehicle.next_node)
 
         if vehicle not in queue:
             current_vehicle_list.remove(vehicle)

--- a/ruth/simulator/route.py
+++ b/ruth/simulator/route.py
@@ -28,12 +28,14 @@ def move_on_segment(
     current_segment = driving_route[segment_position.index]
     assert segment_position.position <= current_segment.length
 
-    if vehicle.segment_position.index < len(driving_route):
-        if start_position == current_segment.length:
-            # if the car is at the end of a segment, we want to work with the next segment
-            start_position = LengthMeters(0.0)
-            segment_position = SegmentPosition(segment_position.index + 1, start_position)
-            current_segment = driving_route[segment_position.index]
+    if vehicle.segment_position.index < len(driving_route) and start_position == current_segment.length:
+        # if the vehicle is at the end of a segment and there are more segments in the route
+        if vehicle.has_next_segment_closed():
+            return current_time + vehicle.frequency, vehicle.segment_position, SpeedMps(0.0)
+        # if the vehicle can move to the next segment, work with the next segment
+        start_position = LengthMeters(0.0)
+        segment_position = SegmentPosition(segment_position.index + 1, start_position)
+        current_segment = driving_route[segment_position.index]
 
         level_of_service = gv_db.gv.level_of_service_in_front_of_vehicle(current_time, current_segment, vehicle.id,
                                                                          start_position, count_vehicles_tolerance)

--- a/ruth/simulator/simulation.py
+++ b/ruth/simulator/simulation.py
@@ -162,40 +162,6 @@ class Simulation:
     def finished(self):
         return all(not v.active for v in self.vehicles)
 
-    def print_car_stats(self):
-        done = 0
-        done_2 = 0
-        total = 0
-        total_2 = 0
-        not_started = 0
-        active = 0
-        finished = 0
-        other = 0
-        for v in self.vehicles:
-            if (not v. active and v.start_index == 0) or v.osm_route is None:
-                not_started += 1
-            elif v.active:
-                active += 1
-                done += v.start_index
-                done_2 += v.start_index
-                total += len(v.osm_route)
-                total_2 += len(v.osm_route)
-            elif v.next_node is None or v.next_node == v.dest_node:
-                finished += 1
-                done += v.start_index
-                total += len(v.osm_route)
-            else:
-                other += 1
-
-        print(f'done segments total: {done}/{total} -> {round(done*100/total, 2)}%')
-        print(f'done segments for active: {done_2}/{total_2} -> {round(done_2 * 100 / total_2, 2)}%')
-        print(f'cars not started: {not_started}')
-        all_cars = active + finished
-        print(f'cars active: {active}/{all_cars} -> {round(active*100/all_cars, 2)}%')
-        print(f'cars finished: {finished}/{all_cars} -> {round(finished*100/all_cars, 2)}%')
-        print(f'cars other: {other}')
-        return
-
     def store(self, path):
         with open(path, 'wb') as f:
             pickle.dump(self, f)

--- a/ruth/simulator/singlenode.py
+++ b/ruth/simulator/singlenode.py
@@ -59,7 +59,7 @@ class Simulator:
             length=100,
             max_speed=100,
             profiles=profiles
-        ) for node_id in list(self.sim.routing_map.network.nodes())]
+        ) for node_id in list(self.sim.routing_map.original_network.nodes())]
         route_selection_provider.update_segment_profiles(profiles)
 
         step = self.sim.number_of_steps
@@ -75,9 +75,7 @@ class Simulator:
             with timer_set.get("update_map_speeds"):
                 self.sim.routing_map.update_temporary_max_speeds(self.sim.setting.departure_time + self.current_offset)
                 if self.current_offset - last_map_update >= self.sim.setting.map_update_freq_s:
-                    new_speeds = [self.sim.global_view.get_segment_speed(node_from,
-                                                                         node_to,
-                                                                         self.sim.routing_map)
+                    new_speeds = [self.sim.global_view.get_segment_speed(node_from, node_to)
                                   for node_from, node_to in segments_changed_speed]
                     self.sim.routing_map.update_current_speeds(segments_changed_speed, new_speeds)
                     alternatives_provider.load_map(self.sim.routing_map)
@@ -97,6 +95,7 @@ class Simulator:
                     need_new_route,
                     k=self.sim.setting.k_alternatives
                 )
+                alts = alternatives_provider.remove_infinity_alternatives(alts, self.sim.routing_map)
                 assert len(alts) == len(need_new_route)
 
             # Find which vehicles should have their routes recomputed

--- a/ruth/tools/globalview2aggregatedfcd.py
+++ b/ruth/tools/globalview2aggregatedfcd.py
@@ -41,7 +41,7 @@ def aggregate(sim_path, round_freq_s, out=None):
 
     m = sim.routing_map
     segment_data = dict()
-    for u, v, data in m.network.edges(data=True):
+    for u, v, data in m.original_network.edges(data=True):
         if "length" in data:
             segment_data[(u, v)] = (data["length"], data['speed_kph'])
         else:

--- a/ruth/tools/simulator.py
+++ b/ruth/tools/simulator.py
@@ -54,7 +54,8 @@ def prepare_simulator(common_args: CommonArgs, vehicles_path) -> SingleNodeSimul
                         count_vehicles_tolerance_s, seed, speeds_path=speeds_path)
         vehicles = load_vehicles(vehicles_path)
         simulation = Simulation(vehicles, ss)
-        vehicles[0].routing_map.init_temporary_max_speeds(speeds_path)
+        if speeds_path is not None:
+            vehicles[0].routing_map.init_temporary_max_speeds(speeds_path)
     else:
         simulation = sim_state
 

--- a/ruth/tools/simulator.py
+++ b/ruth/tools/simulator.py
@@ -54,6 +54,7 @@ def prepare_simulator(common_args: CommonArgs, vehicles_path) -> SingleNodeSimul
                         count_vehicles_tolerance_s, seed, speeds_path=speeds_path)
         vehicles = load_vehicles(vehicles_path)
         simulation = Simulation(vehicles, ss)
+        vehicles[0].routing_map.init_temporary_max_speeds(speeds_path)
     else:
         simulation = sim_state
 

--- a/ruth/vehicle.py
+++ b/ruth/vehicle.py
@@ -138,6 +138,11 @@ class Vehicle:
             print(f"vehicle: {self.id}: {ex}", file=sys.stderr)
             return None
 
+    def has_next_segment_closed(self) -> bool:
+        next_segment_from, next_segment_to = self.osm_route[self.start_index + 1], self.osm_route[self.start_index + 2]
+        max_speed_on_next_segment = self.routing_map.get_current_max_speed(next_segment_from, next_segment_to)
+        return max_speed_on_next_segment == 0.0
+
     def update_followup_route(self, osm_route: Route):
         """
         Updates the route from the current node to the destination node.

--- a/ruth/vehicle.py
+++ b/ruth/vehicle.py
@@ -73,6 +73,9 @@ class Vehicle:
         self.__dict__.update(state)
         self.__post_init__(None)
 
+    def __eq__(self, other):
+        return self.id == other.id
+
     @property
     def next_routing_od_nodes(self) -> Tuple[int, int]:
         return self.next_routing_start.node, self.dest_node


### PR DESCRIPTION
It is now possible to set the "from" and the "to" timestamp of a temporary maximum speed for a segment. These max speeds are now used only for routing, not calculating the LoS. Therefore, two different networks are in the Map class. The alternative routes are filtered so the ones containing a temporarily closed segment are not used. 
When a segment is closed, vehicles don't enter, but those already in the segment finish it.
Aggregating data for generating the probability profiles doesn't use the temporary max speeds anymore. The format of the aggregated output is now "segment_osm_id;timestamp;segment_length;max_speed;current_speed" and it contains data for all the segments for the whole time window.
