### PR TITLE
Improve queues

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "k-alternatives": 1,
     "map-update-freq-s" : 1,
     "los-vehicles-tolerance-s" : 5,
+    "travel-time-limit-perc" : 0.1,
     "out" : "simulation_record.pickle",
     "seed": 7,
     "walltime-s" : 2000,

--- a/ruth/data/map.py
+++ b/ruth/data/map.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+from time import time
 
 import networkx as nx
 import osmnx as ox
@@ -96,11 +97,12 @@ class Map:
             self._store()
 
         if save_hdf:
-            self.hdf5_file_path = str((Path(self.data_dir) / "map.hdf5").absolute())
+            hdf5_file_name = f"map_{round(time() * 1000)}_{os.getpid()}.hdf5"
+            self.hdf5_file_path = str((Path(self.data_dir) / hdf5_file_name).absolute())
             self.save_hdf()
 
     def save_hdf(self) -> str:
-        temp_path = str((Path(self.data_dir) / "map-temp.hdf5").absolute())
+        temp_path = str((Path(self.data_dir) / f"map_{round(time() * 1000)}_{os.getpid()}_temp.hdf5").absolute())
 
         self.osm_to_hdf_map_ids = save_graph_to_hdf5(self.current_network, temp_path)
         self.hdf_to_osm_map_ids = {v: k for (k, v) in self.osm_to_hdf_map_ids.items()}

--- a/ruth/data/map.py
+++ b/ruth/data/map.py
@@ -130,9 +130,16 @@ class Map:
     def edges(self):
         return self.current_network.edges()
 
-    def get_travel_time(self, node_from: int, node_to: int, speed_kph: SpeedKph):
-        return float('inf') if speed_kph == 0 else float(
-            self.segment_lengths[(node_from, node_to)]) * 3.6 / float(speed_kph)
+    def get_travel_time(self, node_from: int, node_to: int, speed_kph: SpeedKph) -> float:
+        if speed_kph == 0:
+            return float('inf')
+        segment_length_m = float(self.segment_lengths[(node_from, node_to)])
+        speed_mps = float(speed_kph) / 3.6
+        travel_time_s = segment_length_m / speed_mps
+        return travel_time_s
+
+    def get_path_travel_time(self, path: List[int]):
+        return nx.path_weight(self.current_network, path, weight='current_travel_time')
 
     def init_current_speeds(self):
         speeds = nx.get_edge_attributes(self.current_network, name='speed_kph')

--- a/ruth/simulator/simulation.py
+++ b/ruth/simulator/simulation.py
@@ -61,6 +61,7 @@ class SimSetting:
     k_alternatives: int = 1
     map_update_freq_s: timedelta = timedelta(seconds=1)
     los_vehicles_tolerance: timedelta = timedelta(seconds=0)
+    travel_time_limit_perc: float = 0.0
     seed: InitVar = None
     speeds_path: str = None
 

--- a/ruth/simulator/simulation.py
+++ b/ruth/simulator/simulation.py
@@ -105,6 +105,13 @@ class Simulation:
     def __setstate__(self, d):
         self.__dict__.update(d)
         self.routing_map = Map(self.bbox, download_date=self.map_download_date, with_speeds=True)
+        current_offset = self.compute_current_offset()
+        if current_offset is not None:
+            current_offset = self.setting.departure_time + current_offset
+            fcds = [fcd for fcd in self.history.fcd_history if fcd.datetime >= current_offset]
+            self.global_view = GlobalView()
+            for fcd in fcds:
+                self.global_view.add(fcd)
 
     @property
     def random(self):

--- a/ruth/simulator/singlenode.py
+++ b/ruth/simulator/singlenode.py
@@ -95,7 +95,7 @@ class Simulator:
                 selected_plans = select_routes(route_selection_providers, new_vehicle_routes)
                 assert len(selected_plans) == len(new_vehicle_routes)
                 for (vehicle, route) in selected_plans:
-                    vehicle.update_followup_route(route)
+                    vehicle.update_followup_route(route, self.sim.routing_map. self.sim.setting.travel_time_limit_perc)
 
             with timer_set.get("advance_vehicle"):
                 fcds = self.advance_vehicles(vehicles_to_be_moved.copy(), offset)

--- a/ruth/simulator/singlenode.py
+++ b/ruth/simulator/singlenode.py
@@ -95,7 +95,7 @@ class Simulator:
                 selected_plans = select_routes(route_selection_providers, new_vehicle_routes)
                 assert len(selected_plans) == len(new_vehicle_routes)
                 for (vehicle, route) in selected_plans:
-                    vehicle.update_followup_route(route, self.sim.routing_map. self.sim.setting.travel_time_limit_perc)
+                    vehicle.update_followup_route(route, self.sim.routing_map, self.sim.setting.travel_time_limit_perc)
 
             with timer_set.get("advance_vehicle"):
                 fcds = self.advance_vehicles(vehicles_to_be_moved.copy(), offset)

--- a/ruth/tools/simulator.py
+++ b/ruth/tools/simulator.py
@@ -30,6 +30,7 @@ class CommonArgs:
     k_alternatives: int
     map_update_freq: timedelta
     los_vehicles_tolerance: timedelta
+    travel_time_limit_perc: float = 0.0
     speeds_path: Optional[str] = None
     out: str = "simulation-record.pickle"
     seed: Optional[int] = None
@@ -80,6 +81,7 @@ def prepare_simulator(common_args: CommonArgs, vehicles_path, alternatives_ratio
     k_alternatives = common_args.k_alternatives
     map_update_freq = common_args.map_update_freq
     los_vehicles_tolerance = common_args.los_vehicles_tolerance
+    travel_time_limit_perc = common_args.travel_time_limit_perc
     seed = common_args.seed
     speeds_path = common_args.speeds_path
     sim_state = common_args.continue_from
@@ -89,7 +91,7 @@ def prepare_simulator(common_args: CommonArgs, vehicles_path, alternatives_ratio
         if vehicles_path is None:
             raise ValueError("Either vehicles_path or continue_from must be specified.")
         ss = SimSetting(departure_time, round_frequency, k_alternatives, map_update_freq,
-                        los_vehicles_tolerance, seed, speeds_path=speeds_path)
+                        los_vehicles_tolerance, travel_time_limit_perc, seed, speeds_path=speeds_path)
         vehicles, bbox, download_date = load_vehicles(vehicles_path)
 
         set_vehicle_behavior(vehicles, alternatives_ratio.to_list(), route_selection_ratio.to_list())
@@ -185,6 +187,7 @@ def start_zeromq_cluster(
 @click.option("--los-vehicles-tolerance-s", type=int, default=1,
               help="Time tolerance (in seconds, of simulation time) to count which cars (i.e., their timestamps)"
                    "are considered for the calculation of LoS in a segment.")
+@click.option("--travel-time-limit-perc", type=float, default=0.0)
 @click.option("--speeds-path", type=click.Path(exists=True),
               help="Path to csv file with temporary max speeds.")
 @click.option("--out", type=str, default="out.pickle")
@@ -203,6 +206,7 @@ def single_node_simulator(ctx,
                           k_alternatives,
                           map_update_freq_s,
                           los_vehicles_tolerance_s,
+                          travel_time_limit_perc,
                           speeds_path,
                           out,
                           seed,
@@ -225,6 +229,7 @@ def single_node_simulator(ctx,
         k_alternatives=k_alternatives,
         map_update_freq=timedelta(seconds=map_update_freq_s),
         los_vehicles_tolerance=timedelta(seconds=los_vehicles_tolerance_s),
+        travel_time_limit_perc=travel_time_limit_perc,
         speeds_path=speeds_path,
         out=out,
         seed=seed,

--- a/ruth/tools/simulator_conf.py
+++ b/ruth/tools/simulator_conf.py
@@ -34,6 +34,8 @@ class CommonArgs(CommonArgsInner):
                                               serializer=lambda x: x.total_seconds(),
                                               deserializer=lambda x: timedelta(seconds=x),
                                               default=timedelta(seconds=5))
+    travel_time_limit_perc: float = field(rename="travel-time-limit-perc",
+                                          default=0.0)
     speeds_path: Optional[str] = field(serializer=lambda x: '' if x is None else x,
                                        deserializer=lambda x: None if x == '' else x,
                                        default=None)

--- a/ruth/vehicle.py
+++ b/ruth/vehicle.py
@@ -79,23 +79,31 @@ def set_vehicle_behavior(vehicles: List['Vehicle'],
     vehicles_shuffled = list(vehicles)
     random.shuffle(vehicles_shuffled)
 
-    n_vehicles_to_change = [int(r * n_vehicles) for r in alternatives_ratio]
+    # select the number of vehicles to change
+    n_vehicles_to_change_alt = [int(r * n_vehicles) for r in alternatives_ratio]
+    sum_n_vehicles_to_change = sum(n_vehicles_to_change_alt)
+    if sum_n_vehicles_to_change != n_vehicles:
+        # add the difference to the DEFAULT
+        n_vehicles_to_change_alt[0] += n_vehicles - sum_n_vehicles_to_change
+
+    n_vehicles_to_change_selection = [int(r * n_vehicles) for r in route_selection_ratio]
+    n_vehicles_to_change_selection = n_vehicles_to_change_alt[0:1] + n_vehicles_to_change_selection[1:]
 
     index_from = 0
-    for n, alternative in zip(n_vehicles_to_change, VehicleAlternatives):
+    for n, alternative in zip(n_vehicles_to_change_alt, VehicleAlternatives):
         index_to = index_from + n
         for v in vehicles_shuffled[index_from:index_to]:
             v.alternatives = alternative
         index_from = index_from + n
 
-    index_from = n_vehicles_to_change[0]
+    index_from = n_vehicles_to_change_alt[0]
     vehicles_with_alternatives = vehicles_shuffled[index_from:]
     vehicles_shuffled = (vehicles_shuffled[:index_from]
                          + random.sample(vehicles_with_alternatives, len(vehicles_with_alternatives)))
     n_vehicles_to_change = [int(r * n_vehicles) for r in route_selection_ratio]
 
     index_from = 0
-    for n, route_selection in zip(n_vehicles_to_change, VehicleRouteSelection):
+    for n, route_selection in zip(n_vehicles_to_change_selection, VehicleRouteSelection):
         index_to = index_from + n
         for v in vehicles_shuffled[index_from:index_to]:
             v.route_selection = route_selection


### PR DESCRIPTION
- During queuing loops over the queues instead of the vehicle list to improve computation speed.
- Add travel-time-limit-per parameter. If this parameter is set to 0.1, the vehicle's route will be changed to calculated alternative only if the alternative is 10% faster (does not apply for dijkstra_shortest alternatives)
- HDF5 map name now dynamically assigned